### PR TITLE
Unify number's parameter name in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 }
 
 func doubleHandler(ctx context.Context, req *apiai.Request) (*apiai.Response, error) {
-	num, err := strconv.Atoi(req.Param("num"))
+	num, err := strconv.Atoi(req.Param("number"))
 	if err != nil {
 		return nil, fmt.Errorf("could not parse number %q: %v", req.Param("number"), err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func doubleHandler(ctx context.Context, req *apiai.Request) (*apiai.Response, error) {
-	num, err := strconv.Atoi(req.Param("num"))
+	num, err := strconv.Atoi(req.Param("number"))
 	if err != nil {
 		return nil, fmt.Errorf("could not parse number %q: %v", req.Param("number"), err)
 	}


### PR DESCRIPTION
`req.Param("number")` was used in the error but `req.Param("num")` was used for the `Atoi`.